### PR TITLE
Update US Passport Photo Guidelines Link.

### DIFF
--- a/HW/HW0-Z.md
+++ b/HW/HW0-Z.md
@@ -8,7 +8,7 @@ This homework will prepare you for basic setup for the course.
 
 Properly setting up your Discord and Moodle profile.
 
-* For Moodle, upload a current headshot picture of you (not anyone else, not a cartoon picture of you, etc.) to your Moodle profile, which will help the teaching staff learn your name. Use [US passport photo guidelines](http://travel.state.gov/passport/pptphotoreq/photocomptemplate/photocomptemplate_5297.html).
+* For Moodle, upload a current headshot picture of you (not anyone else, not a cartoon picture of you, etc.) to your Moodle profile, which will help the teaching staff learn your name. Use [US passport photo guidelines](https://travel.state.gov/content/travel/en/passports/how-apply/photos.html).
 * For Discord, make sure you have your first and last name as part of your profile.
 
 ### Github (5)


### PR DESCRIPTION
The previous link became outdated. This change updates the link.
Additionally, the file was missing a new line character at the end of the file. That was also added.